### PR TITLE
feat: add GitHub repository source links and version tag mappings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/github_repo_links.md
+++ b/.github/PULL_REQUEST_TEMPLATE/github_repo_links.md
@@ -1,0 +1,66 @@
+## 📋 Pull Request: Add GitHub Repository Source Links
+
+### Description
+
+This PR adds GitHub repository source links and version tag mappings to the Java CVE Benchmark dataset, enabling users to directly access the original source code repositories for each vulnerable project.
+
+### Changes
+
+- ✅ Added `vulnerable_version_repo_info.json` containing:
+  - Direct GitHub repository URLs for 60+ Java projects
+  - Version-to-tag mappings for vulnerable versions
+- ✅ Updated `README.md` with:
+  - New "Option 3: GitHub Repository Source Links" section
+  - Updated repository structure documentation
+  - Added GitHub source links to Key Features
+
+### New Data Format
+
+The `vulnerable_version_repo_info.json` file contains:
+```json
+{
+  "library_name_to_github_url": {
+    "library-name": "https://github.com/org/repo"
+  },
+  "library_version_to_tags": {
+    "library-name": {
+      "version": "git-tag"
+    }
+  }
+}
+```
+
+### Usage Example
+
+```bash
+# Clone and checkout a specific vulnerable version
+git clone https://github.com/FasterXML/jackson-databind.git
+cd jackson-databind
+git checkout jackson-databind-2.9.10.7
+```
+
+### ⚠️ Disclaimer
+
+THE GITHUB REPOSITORY LINKS AND VERSION TAG MAPPINGS ARE PROVIDED ON A **BEST-EFFORT BASIS**.
+
+THE INFORMATION IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE INFORMATION OR THE USE OR OTHER DEALINGS IN THE INFORMATION.
+
+- Repository URLs may become unavailable if projects are moved, renamed, or deleted
+- Version tags may not exist for all vulnerable versions
+- Tag names may change over time
+- Some repositories may require authentication or have access restrictions
+
+### Checklist
+
+- [ ] I have verified the GitHub repository URLs are accessible
+- [ ] I have tested the version tag mappings where possible
+- [ ] I have updated the README.md documentation
+- [ ] I have read and agree to the disclaimer above
+
+### Related Issues
+
+Closes #<!-- issue number if applicable -->
+
+---
+
+💡 **Note**: If you find any incorrect or broken links, please open an issue so we can update the database.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ The script will:
 ### Option 2: Manual Selection
 Browse `java_cve_verified_download_urls.csv` to select specific projects and versions for your research needs.
 
+### Option 3: GitHub Repository Source Links
+We also provide direct links to the original GitHub repositories and their version tags in `vulnerable_version_repo_info.json`. This allows you to:
+- 🔗 Access the original source code repositories
+- 🏷️ Checkout specific vulnerable versions using git tags
+- 📂 Clone and build projects locally for deeper analysis
+
+```bash
+# Example: Clone a specific vulnerable version
+git clone https://github.com/FasterXML/jackson-databind.git
+cd jackson-databind
+git checkout jackson-databind-2.9.10.7
+```
+
+> [!WARNING]
+> **Disclaimer**: The GitHub repository links and version tag mappings are provided on a **best-effort basis**. THE INFORMATION IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. Repository availability and tag accuracy may vary over time.
 
 ## 📊 Benchmark Statistics
 
@@ -51,6 +66,7 @@ Browse `java_cve_verified_download_urls.csv` to select specific projects and ver
 .
 ├── README.md                              # This file
 ├── java_cve_verified_download_urls.csv    # Ready-to-use download database
+├── vulnerable_version_repo_info.json      # GitHub repo URLs and version tags
 ├── vuln_data/                             # Vulnerability dataset
 │   ├── README.md                          # Detailed dataset documentation
 │   └── [165 CSV files]                    # Individual CVE data files
@@ -74,6 +90,11 @@ This benchmark is designed for:
 - **Multiple Sources**: Maven Central (109) + GitHub (3)
 - **Ready-to-Use**: No additional URL searching required
 
+### GitHub Repository Source Links
+- **`vulnerable_version_repo_info.json`**: Direct links to 60+ GitHub repositories
+- **Version Tag Mapping**: Git tags for each vulnerable version
+- **Source Code Access**: Clone and checkout specific vulnerable versions
+
 ## 📋 Data Format
 
 Each CSV file in `vuln_data/` follows the naming convention:
@@ -95,6 +116,7 @@ Each CSV file in `vuln_data/` follows the naming convention:
 - ✅ **Method-Level Granularity**: Precise vulnerability localization
 - ✅ **Popular Projects**: High-star GitHub projects ensuring relevance
 - ✅ **Ready-to-Use**: Pre-verified download URLs for immediate access
+- ✅ **GitHub Source Links**: Direct access to original repositories with version tags
 - ✅ **Comprehensive Coverage**: 37 CWE weaknesses across 8 classes
 - ✅ **Research-Grade Quality**: Suitable for academic and industrial research
 

--- a/vulnerable_version_repo_info.json
+++ b/vulnerable_version_repo_info.json
@@ -1,0 +1,302 @@
+{
+    "library_name_to_github_url": {
+        "Openfire": "https://github.com/igniterealtime/Openfire",
+        "Prasanna": "https://github.com/jenkinsci/git-plugin",
+        "Resteasy": "https://github.com/resteasy/resteasy",
+        "active-directory-plugin": "https://github.com/jenkinsci/active-directory-plugin",
+        "async-http-client": "https://github.com/AsyncHttpClient/async-http-client",
+        "brooklyn-server": "https://github.com/apache/brooklyn-server",
+        "commons-compress": "https://github.com/apache/commons-compress",
+        "commons-email": "https://github.com/apache/commons-email",
+        "commons-fileupload": "https://github.com/apache/commons-fileupload",
+        "cron-utils": "https://github.com/jmrozanec/cron-utils",
+        "cxf": "https://github.com/apache/cxf",
+        "cxf-fediz": "https://github.com/apache/cxf-fediz",
+        "directory-ldap-api": "https://github.com/apache/directory-ldap-api",
+        "esapi-java-legacy": "https://github.com/ESAPI/esapi-java-legacy",
+        "fess": "https://github.com/codelibs/fess",
+        "google-oauth-java-client": "https://github.com/googleapis/google-oauth-java-client",
+        "hibernate-validator": "https://github.com/hibernate/hibernate-validator",
+        "jackrabbit": "https://github.com/apache/jackrabbit",
+        "jackson-databind": "https://github.com/FasterXML/jackson-databind",
+        "jackson-dataformat-xml": "https://github.com/FasterXML/jackson-dataformat-xml",
+        "jackson-dataformats-binary": "https://github.com/FasterXML/jackson-dataformats-binary",
+        "jackson-modules-java8": "https://github.com/FasterXML/jackson-modules-java8",
+        "jjbpm-wbbpm": "https://github.com/kiegroup/jbpm-wb",
+        "json-smart-v2": "https://github.com/netplex/json-smart-v2",
+        "jsoup": "https://github.com/jhy/jsoup",
+        "junit4": "https://github.com/junit-team/junit4",
+        "keycloak": "https://github.com/keycloak/keycloak",
+        "libpam4j": "https://github.com/kohsuke/libpam4j",
+        "logback": "https://github.com/qos-ch/logback",
+        "maven-shared-utils": "https://github.com/apache/maven-shared-utils",
+        "myfaces": "https://github.com/apache/myfaces",
+        "netty": "https://github.com/netty/netty",
+        "nv-websocket-client": "https://github.com/TakahikoKawasaki/nv-websocket-client",
+        "orientdb": "https://github.com/orientechnologies/orientdb",
+        "perwendel-spark": "https://github.com/perwendel/spark",
+        "pgjdbc": "https://github.com/pgjdbc/pgjdbc",
+        "picketlink-bindings": "https://github.com/picketlink/picketlink",
+        "plexus-archiver": "https://github.com/codehaus-plexus/plexus-archiver",
+        "plexus-utils": "https://github.com/codehaus-plexus/plexus-utils",
+        "portals-pluto": "https://github.com/apache/portals-pluto",
+        "prime-jwt": "https://github.com/FusionAuth/fusionauth-jwt",
+        "qpid-broker-j": "https://github.com/apache/qpid-broker-j",
+        "qpid-proton-j": "https://github.com/apache/qpid-proton-j",
+        "rdf4j": "https://github.com/eclipse-rdf4j/rdf4j",
+        "retrofit": "https://github.com/square/retrofit",
+        "santuario-java": "https://github.com/apache/santuario-xml-security-java",
+        "script-security-plugin": "https://github.com/jenkinsci/script-security-plugin",
+        "shiro": "https://github.com/apache/shiro",
+        "sling-org-apache-sling-auth-core": "https://github.com/apache/sling-org-apache-sling-auth-core",
+        "sling-org-apache-sling-xss": "https://github.com/apache/sling-org-apache-sling-xss",
+        "snakeyaml": "https://github.com/snakeyaml/snakeyaml",
+        "spring-data-commons": "https://github.com/spring-projects/spring-data-commons",
+        "swagger-codegen": "https://github.com/swagger-api/swagger-codegen",
+        "swagger-parser": "https://github.com/swagger-api/swagger-parser",
+        "tika": "https://github.com/apache/tika",
+        "undertow": "https://github.com/undertow-io/undertow",
+        "velocity-tools": "https://github.com/apache/velocity-tools",
+        "vert.x": "https://github.com/eclipse-vertx/vert.x",
+        "vertx-web": "https://github.com/vert-x3/vertx-web",
+        "weixin-java-tools": "https://github.com/Wechat-Group/WxJava",
+        "xstream": "https://github.com/x-stream/xstream",
+        "zookeeper": "https://github.com/apache/zookeeper",
+        "zt-zip": "https://github.com/zeroturnaround/zt-zip"
+    },
+    "library_version_to_tags": {
+        "Openfire": {
+            "4.4.2": "v4.4.2"
+        },
+        "Prasanna": {
+            "3.9.1": "git-3.9.1"
+        },
+        "Resteasy": {
+            "3.1.1": "3.1.1.Final",
+            "3.5.0": "3.5.0.Final",
+            "4.0.0": "4.0.0.Final"
+        },
+        "active-directory-plugin": {
+            "2.2": "active-directory-2.2"
+        },
+        "async-http-client": {
+            "2.0.29": "async-http-client-project-2.0.29"
+        },
+        "brooklyn-server": {
+            "0.9.0": "rel/apache-brooklyn-0.9.0"
+        },
+        "commons-compress": {
+            "1.0": "rel/1.0",
+            "1.15": "rel/1.15",
+            "1.17": "rel/1.17",
+            "1.18": "rel/1.18",
+            "1.20-RC1": "1.20-RC1",
+            "1.7-RC2": "COMPRESS-1.7-RC2"
+        },
+        "commons-email": {
+            "1_5": "EMAIL_1_5"
+        },
+        "commons-fileupload": {
+            "1.3.2": "FILEUPLOAD_1_3_2",
+            "1_3": "FILEUPLOAD_1_3",
+            "1_3_1": "FILEUPLOAD_1_3_1"
+        },
+        "cron-utils": {
+            "9.0.2": "9.0.2"
+        },
+        "cxf": {
+            "3.1.2": "cxf-3.1.2"
+        },
+        "cxf-fediz": {
+            "1.2.3": "fediz-1.2.3",
+            "1.3.0": "fediz-1.3.0",
+            "1.4.0": "fediz-1.4.0"
+        },
+        "directory-ldap-api": {
+            "1.0.0": "1.0.0"
+        },
+        "esapi-java-legacy": {
+            "2.0": "esapi-2.0GA",
+            "2.1.0": "esapi-2.1.0",
+            "2.2.3.1": "esapi-2.2.3.1"
+        },
+        "fess": {
+            "12.2.0": "fess-12.2.0"
+        },
+        "google-oauth-java-client": {
+            "1.30.5": "v1.30.5"
+        },
+        "hibernate-validator": {
+            "6.1.0": "6.1.0.Final"
+        },
+        "jackrabbit": {
+            "2.8.2": "jackrabbit-2.8.2"
+        },
+        "jackson-databind": {
+            "2.0.0-RC2": "jackson-databind-2.0.0-RC2",
+            "2.0.0-RC3": "jackson-databind-2.0.0-RC3",
+            "2.2.4": "jackson-databind-2.2.4",
+            "2.8.11": "jackson-databind-2.8.11",
+            "2.9.0": "jackson-databind-2.9.0",
+            "2.9.10": "jackson-databind-2.9.10",
+            "2.9.10.5": "jackson-databind-2.9.10.5",
+            "2.9.10.6": "jackson-databind-2.9.10.6",
+            "2.9.10.7": "jackson-databind-2.9.10.7",
+            "2.9.3": "jackson-databind-2.9.3",
+            "2.9.4": "jackson-databind-2.9.4",
+            "2.9.7": "jackson-databind-2.9.7",
+            "2.9.8": "jackson-databind-2.9.8",
+            "2.9.9": "jackson-databind-2.9.9"
+        },
+        "jackson-dataformat-xml": {
+            "2.8.3": "jackson-dataformat-xml-2.8.3"
+        },
+        "jackson-dataformats-binary": {
+            "2.12.0": "jackson-dataformats-binary-2.12.0"
+        },
+        "jackson-modules-java8": {
+            "2.9.6": "jackson-modules-java8-2.9.6"
+        },
+        "jjbpm-wbbpm": {
+            "6.1.0": "6.1.0.Final"
+        },
+        "json-smart-v2": {
+            "2.4.1": "2.4.1"
+        },
+        "jsoup": {
+            "1.8.1": "jsoup-1.8.1.a"
+        },
+        "junit4": {
+            "4.13": "r4.13"
+        },
+        "keycloak": {
+            "1.0.3": "1.0.3.Final"
+        },
+        "libpam4j": {
+            "1.8": "libpam4j-1.8"
+        },
+        "logback": {
+            "1.1.11": "v_1.1.11"
+        },
+        "maven-shared-utils": {
+            "3.3.2": "maven-shared-utils-3.3.2"
+        },
+        "myfaces": {
+            "2.1.5": "myfaces-core-project-2.1.5"
+        },
+        "netty": {
+            "3.4.4": "netty-3.4.4.Final",
+            "3.9.1.1": "netty-3.9.1.Final"
+        },
+        "nv-websocket-client": {
+            "2.2": "nv-websocket-client-2.2"
+        },
+        "orientdb": {
+            "2.1.0": "2.1.0"
+        },
+        "perwendel-spark": {
+            "1.1.1": "1.1.1",
+            "2.5": "2.5"
+        },
+        "pgjdbc": {
+            "42.2.5": "REL42.2.5"
+        },
+        "picketlink-bindings": {
+            "2.6.0": "v2.6.0.Final"
+        },
+        "plexus-archiver": {
+            "3.5": "plexus-archiver-3.5"
+        },
+        "plexus-utils": {
+            "3.0.14": "plexus-utils-3.0.14"
+        },
+        "portals-pluto": {
+            "3.0.0": "pluto-3.0.0"
+        },
+        "prime-jwt": {
+            "1.2.1": "1.2.1",
+            "1.3.0": "1.3.0"
+        },
+        "qpid-broker-j": {
+            "6.0.2": "6.0.2",
+            "6.0.3": "6.0.3",
+            "7.0.4": "7.0.4"
+        },
+        "qpid-proton-j": {
+            "0.15.0": "0.15.0"
+        },
+        "rdf4j": {
+            "2.4.2": "2.4.2"
+        },
+        "retrofit": {
+            "2.4.0": "parent-2.4.0"
+        },
+        "santuario-java": {
+            "1.5.4": "1.5.4",
+            "1.5.5": "1.5.5",
+            "2.1.3": "xmlsec-2.1.3"
+        },
+        "script-security-plugin": {
+            "1.49": "script-security-1.49"
+        },
+        "shiro": {
+            "1.3.1": "shiro-root-1.3.1"
+        },
+        "sling-org-apache-sling-auth-core": {
+            "1.4.0": "org.apache.sling.auth.core-1.4.0"
+        },
+        "sling-org-apache-sling-xss": {
+            "2.0.0": "org.apache.sling.xss-2.0.0"
+        },
+        "snakeyaml": {
+            "1.17": "580e28c3396d8310c31f8777461b7a69870e57db"
+        },
+        "spring-data-commons": {
+            "2.0.0": "2.0.0.RELEASE"
+        },
+        "swagger-codegen": {
+            "2.4.18": "v2.4.18"
+        },
+        "swagger-parser": {
+            "1.0.27": "v1.0.27"
+        },
+        "tika": {
+            "1.13": "1.13",
+            "1.8": "1.8"
+        },
+        "undertow": {
+            "1.1.9": "1.1.9.Final",
+            "1.2.0": "1.2.0.Final",
+            "1.4.7": "1.4.7.Final",
+            "2.0.0": "2.0.0.Final",
+            "2.0.4": "2.0.4.Final"
+        },
+        "velocity-tools": {
+            "3.0": "3.0"
+        },
+        "vert.x": {
+            "3.4.2": "3.4.2",
+            "3.5.3": "3.5.3"
+        },
+        "vertx-web": {
+            "3.5.2": "3.5.2",
+            "3.5.3": "3.5.3",
+            "4.0.0-milestone4": "4.0.0-milestone4"
+        },
+        "weixin-java-tools": {
+            "3.2.0": "v3.2.0"
+        },
+        "xstream": {
+            "1_4_13": "XSTREAM_1_4_13",
+            "1_4_14": "XSTREAM_1_4_14",
+            "1_4_18": "XSTREAM_1_4_18",
+            "1_4_9": "XSTREAM_1_4_9"
+        },
+        "zookeeper": {
+            "3.6.3-2": "release-3.6.3"
+        },
+        "zt-zip": {
+            "1.12": "zt-zip-1.12"
+        }
+    }
+}


### PR DESCRIPTION
Closes #4 

- Add vulnerable_version_repo_info.json with 60+ GitHub repo URLs
- Include version-to-git-tag mappings for vulnerable versions
- Update README.md with new "GitHub Repository Source Links" option
- Document usage examples for cloning specific vulnerable versions